### PR TITLE
Customer portal improvements

### DIFF
--- a/Controller/ViewController.php
+++ b/Controller/ViewController.php
@@ -127,6 +127,23 @@ class ViewController extends AbstractController
         $projects = $this->sharedProjectTimesheetRepository->getProjects($sharedPortal);
         $projectStats = $this->projectStatisticService->getBudgetStatisticModelForProjects($projects, $date);
 
+        // Calculate per-project duration and rate totals for the selected month
+        $projectTotals = [];
+        foreach ($timeRecords as $record) {
+            $project = $record->getProject();
+            if ($project !== null) {
+                $projectId = $project->getId();
+                if (!isset($projectTotals[$projectId])) {
+                    $projectTotals[$projectId] = [
+                        'duration' => 0,
+                        'rate' => 0.0,
+                    ];
+                }
+                $projectTotals[$projectId]['duration'] += $record->getDuration();
+                $projectTotals[$projectId]['rate'] += $record->getRate();
+            }
+        }
+
         return $this->render('@CustomerPortal/view/customer.html.twig', [
             'portal' => $sharedPortal,
             'customer' => $customer,
@@ -142,6 +159,7 @@ class ViewController extends AbstractController
             'detailsMode' => $detailsMode,
             'stats' => $stats,
             'projectStats' => $projectStats,
+            'projectTotals' => $projectTotals,
         ]);
     }
 

--- a/Entity/SharedProjectTimesheet.php
+++ b/Entity/SharedProjectTimesheet.php
@@ -63,6 +63,9 @@ class SharedProjectTimesheet
     #[ORM\Column(name: 'show_total_amount_when_entry_rate_hidden', type: 'boolean', nullable: false, options: ['default' => true])]
     private bool $showTotalAmountWhenEntryRateHidden = true;
 
+    #[ORM\Column(name: 'project_sub_totals_visible', type: 'boolean', nullable: false, options: ['default' => true])]
+    private bool $projectSubTotalsVisible = true;
+
     #[ORM\Column(name: 'record_merge_mode', type: 'string', length: 50, nullable: false)]
     #[Assert\Length(max: 50)]
     private string $recordMergeMode = RecordMergeMode::MODE_NONE;
@@ -177,6 +180,16 @@ class SharedProjectTimesheet
     public function setShowTotalAmountWhenEntryRateHidden(bool $showTotalAmountWhenEntryRateHidden): void
     {
         $this->showTotalAmountWhenEntryRateHidden = $showTotalAmountWhenEntryRateHidden;
+    }
+
+    public function isProjectSubTotalsVisible(): bool
+    {
+        return $this->projectSubTotalsVisible;
+    }
+
+    public function setProjectSubTotalsVisible(bool $projectSubTotalsVisible): void
+    {
+        $this->projectSubTotalsVisible = $projectSubTotalsVisible;
     }
 
     public function hasRecordMerging(): bool

--- a/Entity/SharedProjectTimesheet.php
+++ b/Entity/SharedProjectTimesheet.php
@@ -60,6 +60,9 @@ class SharedProjectTimesheet
     #[ORM\Column(name: 'entry_tags_visible', type: 'boolean', nullable: false, options: ['default' => false])]
     private bool $entryTagsVisible = false;
 
+    #[ORM\Column(name: 'show_total_amount_when_entry_rate_hidden', type: 'boolean', nullable: false, options: ['default' => true])]
+    private bool $showTotalAmountWhenEntryRateHidden = true;
+
     #[ORM\Column(name: 'record_merge_mode', type: 'string', length: 50, nullable: false)]
     #[Assert\Length(max: 50)]
     private string $recordMergeMode = RecordMergeMode::MODE_NONE;
@@ -164,6 +167,16 @@ class SharedProjectTimesheet
     public function setEntryTagsVisible(bool $entryTagsVisible): void
     {
         $this->entryTagsVisible = $entryTagsVisible;
+    }
+
+    public function isShowTotalAmountWhenEntryRateHidden(): bool
+    {
+        return $this->showTotalAmountWhenEntryRateHidden;
+    }
+
+    public function setShowTotalAmountWhenEntryRateHidden(bool $showTotalAmountWhenEntryRateHidden): void
+    {
+        $this->showTotalAmountWhenEntryRateHidden = $showTotalAmountWhenEntryRateHidden;
     }
 
     public function hasRecordMerging(): bool

--- a/Entity/SharedProjectTimesheet.php
+++ b/Entity/SharedProjectTimesheet.php
@@ -54,6 +54,12 @@ class SharedProjectTimesheet
     #[ORM\Column(name: 'entry_rate_visible', type: 'boolean', nullable: false, options: ['default' => false])]
     private bool $entryRateVisible = false;
 
+    #[ORM\Column(name: 'entry_activity_visible', type: 'boolean', nullable: false, options: ['default' => false])]
+    private bool $entryActivityVisible = false;
+
+    #[ORM\Column(name: 'entry_tags_visible', type: 'boolean', nullable: false, options: ['default' => false])]
+    private bool $entryTagsVisible = false;
+
     #[ORM\Column(name: 'record_merge_mode', type: 'string', length: 50, nullable: false)]
     #[Assert\Length(max: 50)]
     private string $recordMergeMode = RecordMergeMode::MODE_NONE;
@@ -138,6 +144,26 @@ class SharedProjectTimesheet
     public function setEntryRateVisible(bool $entryRateVisible): void
     {
         $this->entryRateVisible = $entryRateVisible;
+    }
+
+    public function isEntryActivityVisible(): bool
+    {
+        return $this->entryActivityVisible;
+    }
+
+    public function setEntryActivityVisible(bool $entryActivityVisible): void
+    {
+        $this->entryActivityVisible = $entryActivityVisible;
+    }
+
+    public function isEntryTagsVisible(): bool
+    {
+        return $this->entryTagsVisible;
+    }
+
+    public function setEntryTagsVisible(bool $entryTagsVisible): void
+    {
+        $this->entryTagsVisible = $entryTagsVisible;
     }
 
     public function hasRecordMerging(): bool

--- a/Form/SharedProjectFormType.php
+++ b/Form/SharedProjectFormType.php
@@ -71,6 +71,10 @@ class SharedProjectFormType extends AbstractType
                         'label' => 'shared_project_timesheets.manage.form.entry_rate_visible',
                         'required' => false,
                     ])
+                    ->add('showTotalAmountWhenEntryRateHidden', YesNoType::class, [
+                        'label' => 'shared_project_timesheets.manage.form.show_total_amount_when_entry_rate_hidden',
+                        'required' => false,
+                    ])
                     ->add('entryActivityVisible', YesNoType::class, [
                         'label' => 'shared_project_timesheets.manage.form.entry_activity_visible',
                         'required' => false,

--- a/Form/SharedProjectFormType.php
+++ b/Form/SharedProjectFormType.php
@@ -67,6 +67,14 @@ class SharedProjectFormType extends AbstractType
                         'label' => 'shared_project_timesheets.manage.form.entry_user_visible',
                         'required' => false,
                     ])
+                    ->add('entryActivityVisible', YesNoType::class, [
+                        'label' => 'shared_project_timesheets.manage.form.entry_activity_visible',
+                        'required' => false,
+                    ])
+                    ->add('entryTagsVisible', YesNoType::class, [
+                        'label' => 'shared_project_timesheets.manage.form.entry_tags_visible',
+                        'required' => false,
+                    ])
                     ->add('entryRateVisible', YesNoType::class, [
                         'label' => 'shared_project_timesheets.manage.form.entry_rate_visible',
                         'required' => false,
@@ -75,12 +83,8 @@ class SharedProjectFormType extends AbstractType
                         'label' => 'shared_project_timesheets.manage.form.show_total_amount_when_entry_rate_hidden',
                         'required' => false,
                     ])
-                    ->add('entryActivityVisible', YesNoType::class, [
-                        'label' => 'shared_project_timesheets.manage.form.entry_activity_visible',
-                        'required' => false,
-                    ])
-                    ->add('entryTagsVisible', YesNoType::class, [
-                        'label' => 'shared_project_timesheets.manage.form.entry_tags_visible',
+                    ->add('projectSubTotalsVisible', YesNoType::class, [
+                        'label' => 'shared_project_timesheets.manage.form.project_sub_totals_visible',
                         'required' => false,
                     ])
             )

--- a/Form/SharedProjectFormType.php
+++ b/Form/SharedProjectFormType.php
@@ -71,6 +71,14 @@ class SharedProjectFormType extends AbstractType
                         'label' => 'shared_project_timesheets.manage.form.entry_rate_visible',
                         'required' => false,
                     ])
+                    ->add('entryActivityVisible', YesNoType::class, [
+                        'label' => 'shared_project_timesheets.manage.form.entry_activity_visible',
+                        'required' => false,
+                    ])
+                    ->add('entryTagsVisible', YesNoType::class, [
+                        'label' => 'shared_project_timesheets.manage.form.entry_tags_visible',
+                        'required' => false,
+                    ])
             )
             ->add(
                 $builder

--- a/Migrations/Version20251125165015.php
+++ b/Migrations/Version20251125165015.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the "Customer-Portal plugin" for Kimai.
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\CustomerPortalBundle\Migrations;
+
+use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * @version 4.6.0
+ */
+final class Version20251125165015 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add entry_activity_visible and entry_tags_visible columns to customer portals';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('kimai2_customer_portals');
+
+        if (!$table->hasColumn('entry_activity_visible')) {
+            $table->addColumn('entry_activity_visible', 'boolean', [
+                'default' => false,
+                'notnull' => true,
+            ]);
+        }
+
+        if (!$table->hasColumn('entry_tags_visible')) {
+            $table->addColumn('entry_tags_visible', 'boolean', [
+                'default' => false,
+                'notnull' => true,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('kimai2_customer_portals');
+
+        if ($table->hasColumn('entry_activity_visible')) {
+            $table->dropColumn('entry_activity_visible');
+        }
+
+        if ($table->hasColumn('entry_tags_visible')) {
+            $table->dropColumn('entry_tags_visible');
+        }
+    }
+}

--- a/Migrations/Version20251126120000.php
+++ b/Migrations/Version20251126120000.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the "Customer-Portal plugin" for Kimai.
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace KimaiPlugin\CustomerPortalBundle\Migrations;
+
+use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * @version 4.6.0
+ */
+final class Version20251126120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add show_total_amount_when_entry_rate_hidden column to customer portals';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('kimai2_customer_portals');
+
+        if (!$table->hasColumn('show_total_amount_when_entry_rate_hidden')) {
+            $table->addColumn('show_total_amount_when_entry_rate_hidden', 'boolean', [
+                'default' => true,
+                'notnull' => true,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('kimai2_customer_portals');
+
+        if ($table->hasColumn('show_total_amount_when_entry_rate_hidden')) {
+            $table->dropColumn('show_total_amount_when_entry_rate_hidden');
+        }
+    }
+}

--- a/Migrations/Version20251126150000.php
+++ b/Migrations/Version20251126150000.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace KimaiPlugin\CustomerPortalBundle\Migrations;
+
+use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * @version 4.6.0
+ */
+final class Version20251126150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add project_sub_totals_visible column to customer portals';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->getTable('kimai2_customer_portals');
+
+        if (!$table->hasColumn('project_sub_totals_visible')) {
+            $table->addColumn('project_sub_totals_visible', 'boolean', [
+                'default' => true,
+                'notnull' => true,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $table = $schema->getTable('kimai2_customer_portals');
+
+        if ($table->hasColumn('project_sub_totals_visible')) {
+            $table->dropColumn('project_sub_totals_visible');
+        }
+    }
+}

--- a/Migrations/Version20251126150000.php
+++ b/Migrations/Version20251126150000.php
@@ -1,10 +1,16 @@
 <?php
 
+/*
+ * This file is part of the "Customer-Portal plugin" for Kimai.
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
 namespace KimaiPlugin\CustomerPortalBundle\Migrations;
 
 use App\Doctrine\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;
-
 /**
  * @version 4.6.0
  */

--- a/Resources/translations/messages.de.yaml
+++ b/Resources/translations/messages.de.yaml
@@ -8,6 +8,8 @@ shared_project_timesheets:
             table_options: Detailtabelle - Optionen
             entry_user_visible: Benutzer sichtbar
             entry_rate_visible: Kosten sichtbar
+            entry_activity_visible: Aktivität sichtbar
+            entry_tags_visible: Tags sichtbar
             chart_options: Diagramme - Optionen
             annual_chart_visible: Jahresdiagramm sichtbar
             monthly_chart_visible: Monatsdiagramm sichtbar
@@ -18,6 +20,8 @@ shared_project_timesheets:
             record_merge_mode: Zeiten zusammenführen
             entry_user_visible: Benutzer sichtbar
             entry_rate_visible: Kosten sichtbar
+            entry_activity_visible: Aktivität sichtbar
+            entry_tags_visible: Tags sichtbar
             annual_chart_visible: Jahresdiagramm sichtbar
             monthly_chart_visible: Monatsdiagramm sichtbar
 

--- a/Resources/translations/messages.de.yaml
+++ b/Resources/translations/messages.de.yaml
@@ -10,6 +10,7 @@ shared_project_timesheets:
             entry_rate_visible: Kosten sichtbar
             entry_activity_visible: Aktivität sichtbar
             entry_tags_visible: Tags sichtbar
+            show_total_amount_when_entry_rate_hidden: Gesamtbetrag anzeigen, wenn Eingabesatz ausgeblendet ist
             chart_options: Diagramme - Optionen
             annual_chart_visible: Jahresdiagramm sichtbar
             monthly_chart_visible: Monatsdiagramm sichtbar
@@ -22,6 +23,7 @@ shared_project_timesheets:
             entry_rate_visible: Kosten sichtbar
             entry_activity_visible: Aktivität sichtbar
             entry_tags_visible: Tags sichtbar
+            show_total_amount_when_entry_rate_hidden: Summe anzeigen wenn Satz verborgen
             annual_chart_visible: Jahresdiagramm sichtbar
             monthly_chart_visible: Monatsdiagramm sichtbar
 

--- a/Resources/translations/messages.de.yaml
+++ b/Resources/translations/messages.de.yaml
@@ -17,6 +17,7 @@ shared_project_timesheets:
             statistics_options: Projektstatistiken - Optionen
             budget_stats_visible: Budgetstatistiken sichtbar
             time_budget_stats_visible: Zeitbudgetstatistiken sichtbar
+            project_sub_totals_visible: Projekt-Zwischensummen sichtbar
         table:
             record_merge_mode: Zeiten zusammenführen
             entry_user_visible: Benutzer sichtbar
@@ -26,6 +27,7 @@ shared_project_timesheets:
             show_total_amount_when_entry_rate_hidden: Summe anzeigen wenn Satz verborgen
             annual_chart_visible: Jahresdiagramm sichtbar
             monthly_chart_visible: Monatsdiagramm sichtbar
+            project_sub_totals_visible: Projekt-Zwischensummen sichtbar
 
     view:
         table:

--- a/Resources/translations/messages.en.yaml
+++ b/Resources/translations/messages.en.yaml
@@ -10,6 +10,7 @@ shared_project_timesheets:
             entry_rate_visible: Entry rate visible
             entry_activity_visible: Entry activity visible
             entry_tags_visible: Entry tags visible
+            show_total_amount_when_entry_rate_hidden: Show total amount when entry rate hidden
             chart_options: Chart options
             annual_chart_visible: Annual chart visible
             monthly_chart_visible: Monthly chart visible
@@ -22,6 +23,7 @@ shared_project_timesheets:
             entry_rate_visible: Entry rate visible
             entry_activity_visible: Entry activity visible
             entry_tags_visible: Entry tags visible
+            show_total_amount_when_entry_rate_hidden: Show total when rate hidden
             annual_chart_visible: Annual chart visible
             monthly_chart_visible: Monthly chart visible
 

--- a/Resources/translations/messages.en.yaml
+++ b/Resources/translations/messages.en.yaml
@@ -17,6 +17,7 @@ shared_project_timesheets:
             statistics_options: Statistics options
             budget_stats_visible: Budget statistics visible
             time_budget_stats_visible: Time budget statistics visible
+            project_sub_totals_visible: Project sub-totals visible
         table:
             record_merge_mode: Merge records
             entry_user_visible: Entry user visible
@@ -26,6 +27,7 @@ shared_project_timesheets:
             show_total_amount_when_entry_rate_hidden: Show total when rate hidden
             annual_chart_visible: Annual chart visible
             monthly_chart_visible: Monthly chart visible
+            project_sub_totals_visible: Project sub-totals visible
 
     view:
         table:

--- a/Resources/translations/messages.en.yaml
+++ b/Resources/translations/messages.en.yaml
@@ -8,6 +8,8 @@ shared_project_timesheets:
             table_options: Timesheet table options
             entry_user_visible: Entry user visible
             entry_rate_visible: Entry rate visible
+            entry_activity_visible: Entry activity visible
+            entry_tags_visible: Entry tags visible
             chart_options: Chart options
             annual_chart_visible: Annual chart visible
             monthly_chart_visible: Monthly chart visible
@@ -18,6 +20,8 @@ shared_project_timesheets:
             record_merge_mode: Merge records
             entry_user_visible: Entry user visible
             entry_rate_visible: Entry rate visible
+            entry_activity_visible: Entry activity visible
+            entry_tags_visible: Entry tags visible
             annual_chart_visible: Annual chart visible
             monthly_chart_visible: Monthly chart visible
 

--- a/Resources/views/view/customer.html.twig
+++ b/Resources/views/view/customer.html.twig
@@ -275,6 +275,8 @@
                             set project_url = url('customer_portal_project', {
                                 'shareKey': portal.shareKey,
                                 'project': project.getId(),
+                                'year': year,
+                                'month': month,
                             })
                         %}
                         <tr class="alternative-link" data-href="{{ project_url }}">

--- a/Resources/views/view/customer.html.twig
+++ b/Resources/views/view/customer.html.twig
@@ -262,6 +262,10 @@
                             {% if (portal.isBudgetStatsVisible() or portal.isTimeBudgetStatsVisible()) %}
                                 <th></th>
                             {% endif %}
+                            {% if portal.projectSubTotalsVisible %}
+                                <th class="w-min text-end">{{ 'duration'|trans }}</th>
+                                <th class="w-min">{{ 'total_rate'|trans }}</th>
+                            {% endif %}
                             <th class="w-min"></th>
                         </tr>
                     </thead>
@@ -282,6 +286,23 @@
                                     {% endif %}
                                     {% if stats.hasTimeBudget() and portal.isTimeBudgetStatsVisible() %}
                                         {{ progress.progressbar_timebudget(stats) }}
+                                    {% endif %}
+                                </td>
+                            {% endif %}
+                            {% if portal.projectSubTotalsVisible %}
+                                {% set totals = projectTotals[project.getId()] ?? null %}
+                                <td class="text-end">
+                                    {% if totals %}
+                                        {{ totals.duration | duration }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if totals %}
+                                        {{ totals.rate | format_currency(currency) }}
+                                    {% else %}
+                                        -
                                     {% endif %}
                                 </td>
                             {% endif %}

--- a/Resources/views/view/customer.html.twig
+++ b/Resources/views/view/customer.html.twig
@@ -152,8 +152,14 @@
                             <th>{{ 'user' | trans }}</th>
                             {% endif %}
                             <th>{{ 'project' | trans }}</th>
+                            {% if portal.entryActivityVisible %}
+                            <th>{{ 'activity' | trans }}</th>
+                            {% endif %}
                             <th>{{ 'description' | trans }}</th>
-                            <th class="w-min">{{ 'duration'|trans }}</th>
+                            {% if portal.entryTagsVisible %}
+                            <th>{{ 'tags' | trans }}</th>
+                            {% endif %}
+                            <th class="w-min text-end">{{ 'duration'|trans }}</th>
                             {% if portal.entryRateVisible %}
                             <th class="w-min">{{ 'hourlyRate' | trans }}</th>
                             <th class="w-min">{{ 'total_rate' | trans }}</th>
@@ -167,8 +173,22 @@
                                 <td>{{ record.user.displayName }}</td>
                             {% endif %}
                             <td>{{ record.getProject.name }}</td>
+                            {% if portal.entryActivityVisible %}
+                                <td>{{ record.activityName }}</td>
+                            {% endif %}
                             <td>{{ record.description | e | nl2br }}</td>
-                            <td>{{ record.duration | duration }}</td>
+                            {% if portal.entryTagsVisible %}
+                                <td>
+                                    {% if record.tags is not empty %}
+                                        {% for tag in record.tags %}
+                                            <span class="badge bg-secondary" style="background-color: rgba(var(--tblr-secondary-rgb), 0.1) !important;">
+                                                <span style="display: inline-block; width: 10px; height: 10px; background-color: {{ tag.color|default('#6c757d') }}; margin-right: 5px; vertical-align: middle;"></span>{{ tag.name }}
+                                            </span>
+                                        {% endfor %}
+                                    {% endif %}
+                                </td>
+                            {% endif %}
+                            <td class="text-end">{{ record.duration | duration }}</td>
                             {% if portal.entryRateVisible %}
                                 {% if record.differentHourlyRates %}
                                     <td>
@@ -195,8 +215,20 @@
                             <td></td>
                             {% endif %}
                             <td></td>
+                            {% if portal.entryActivityVisible %}
                             <td></td>
-                            <td>{{ durationSum | duration }}</td>
+                            {% endif %}
+                            <td></td>
+                            {% if portal.entryTagsVisible %}
+                            <td></td>
+                            {% endif %}
+                            <td class="text-end">
+                                {% if portal.entryRateVisible %}
+                                    {{ durationSum | duration }}
+                                {% else %}
+                                    {{ durationSum | duration }}<br>{{ rateSum | format_currency(currency) }}
+                                {% endif %}
+                            </td>
                             {% if portal.entryRateVisible %}
                             <td></td>
                             <td>{{ rateSum | format_currency(currency) }}</td>

--- a/Resources/views/view/customer.html.twig
+++ b/Resources/views/view/customer.html.twig
@@ -226,7 +226,11 @@
                                 {% if portal.entryRateVisible %}
                                     {{ durationSum | duration }}
                                 {% else %}
-                                    {{ durationSum | duration }}<br>{{ rateSum | format_currency(currency) }}
+                                    {% if portal.showTotalAmountWhenEntryRateHidden %}
+                                        {{ durationSum | duration }}<br>{{ rateSum | format_currency(currency) }}
+                                    {% else %}
+                                        {{ durationSum | duration }}
+                                    {% endif %}
                                 {% endif %}
                             </td>
                             {% if portal.entryRateVisible %}

--- a/Resources/views/view/project.html.twig
+++ b/Resources/views/view/project.html.twig
@@ -223,7 +223,11 @@
                                 {% if portal.entryRateVisible %}
                                     {{ durationSum | duration }}
                                 {% else %}
-                                    {{ durationSum | duration }}<br>{{ rateSum | format_currency(currency) }}
+                                    {% if portal.showTotalAmountWhenEntryRateHidden %}
+                                        {{ durationSum | duration }}<br>{{ rateSum | format_currency(currency) }}
+                                    {% else %}
+                                        {{ durationSum | duration }}
+                                    {% endif %}
                                 {% endif %}
                             </td>
                             {% if portal.entryRateVisible %}

--- a/Resources/views/view/project.html.twig
+++ b/Resources/views/view/project.html.twig
@@ -151,8 +151,14 @@
                             {% if portal.entryUserVisible %}
                             <th>{{ 'user' | trans }}</th>
                             {% endif %}
+                            {% if portal.entryActivityVisible %}
+                            <th>{{ 'activity' | trans }}</th>
+                            {% endif %}
                             <th>{{ 'description' | trans }}</th>
-                            <th class="w-min">{{ 'duration'|trans }}</th>
+                            {% if portal.entryTagsVisible %}
+                            <th>{{ 'tags' | trans }}</th>
+                            {% endif %}
+                            <th class="w-min text-end">{{ 'duration'|trans }}</th>
                             {% if portal.entryRateVisible %}
                             <th class="w-min">{{ 'hourlyRate' | trans }}</th>
                             <th class="w-min">{{ 'total_rate' | trans }}</th>
@@ -165,8 +171,22 @@
                             {% if portal.entryUserVisible %}
                                 <td>{{ record.user.displayName }}</td>
                             {% endif %}
+                            {% if portal.entryActivityVisible %}
+                                <td>{{ record.activityName }}</td>
+                            {% endif %}
                             <td>{{ record.description | e | nl2br }}</td>
-                            <td>{{ record.duration | duration }}</td>
+                            {% if portal.entryTagsVisible %}
+                                <td>
+                                    {% if record.tags is not empty %}
+                                        {% for tag in record.tags %}
+                                            <span class="badge bg-secondary" style="background-color: rgba(var(--tblr-secondary-rgb), 0.1) !important;">
+                                                <span style="display: inline-block; width: 10px; height: 10px; background-color: {{ tag.color|default('#6c757d') }}; margin-right: 5px; vertical-align: middle;"></span>{{ tag.name }}
+                                            </span>
+                                        {% endfor %}
+                                    {% endif %}
+                                </td>
+                            {% endif %}
+                            <td class="text-end">{{ record.duration | duration }}</td>
                             {% if portal.entryRateVisible %}
                                 {% if record.differentHourlyRates %}
                                     <td>
@@ -192,8 +212,20 @@
                             {% if portal.entryUserVisible %}
                             <td></td>
                             {% endif %}
+                            {% if portal.entryActivityVisible %}
                             <td></td>
-                            <td>{{ durationSum | duration }}</td>
+                            {% endif %}
+                            <td></td>
+                            {% if portal.entryTagsVisible %}
+                            <td></td>
+                            {% endif %}
+                            <td class="text-end">
+                                {% if portal.entryRateVisible %}
+                                    {{ durationSum | duration }}
+                                {% else %}
+                                    {{ durationSum | duration }}<br>{{ rateSum | format_currency(currency) }}
+                                {% endif %}
+                            </td>
                             {% if portal.entryRateVisible %}
                             <td></td>
                             <td>{{ rateSum | format_currency(currency) }}</td>

--- a/Resources/views/view/project.html.twig
+++ b/Resources/views/view/project.html.twig
@@ -74,7 +74,12 @@
             </a>
         </div>
 
-        <span class="ps-2">{{ project.name }}</span>
+        <span class="ps-2">
+            {% if project.customer and portal.customer %}
+                <a href="{{ url('customer_portal_view', {shareKey: portal.shareKey, year: year, month: month}) }}" class="text-decoration-underline">{{ project.customer.name }}</a><span class="text-body-secondary ps-3 pe-2"><i class="fa fa-caret-right"></i></span>
+            {% endif %}
+            {{ project.name }}
+        </span>
     </h2>
 
     {% if show_month_stats %}

--- a/tests/Service/ManageServiceTest.php
+++ b/tests/Service/ManageServiceTest.php
@@ -44,6 +44,7 @@ class ManageServiceTest extends TestCase
         $sharedProjectTimesheet->setRecordMergeMode(RecordMergeMode::MODE_MERGE);
         $sharedProjectTimesheet->setEntryUserVisible(true);
         $sharedProjectTimesheet->setEntryRateVisible(true);
+        $sharedProjectTimesheet->setShowTotalAmountWhenEntryRateHidden(false);
         $sharedProjectTimesheet->setAnnualChartVisible(true);
         $sharedProjectTimesheet->setMonthlyChartVisible(true);
 
@@ -55,6 +56,7 @@ class ManageServiceTest extends TestCase
         self::assertEquals(RecordMergeMode::MODE_MERGE, $saved->getRecordMergeMode());
         self::assertTrue($saved->isEntryUserVisible());
         self::assertTrue($saved->isEntryRateVisible());
+        self::assertFalse($saved->isShowTotalAmountWhenEntryRateHidden());
         self::assertTrue($saved->isAnnualChartVisible());
         self::assertTrue($saved->isMonthlyChartVisible());
     }
@@ -68,6 +70,7 @@ class ManageServiceTest extends TestCase
         self::assertEquals(RecordMergeMode::MODE_NONE, $sharedProjectTimesheet->getRecordMergeMode());
         self::assertFalse($sharedProjectTimesheet->isEntryUserVisible());
         self::assertFalse($sharedProjectTimesheet->isEntryRateVisible());
+        self::assertTrue($sharedProjectTimesheet->isShowTotalAmountWhenEntryRateHidden());
         self::assertFalse($sharedProjectTimesheet->isAnnualChartVisible());
         self::assertFalse($sharedProjectTimesheet->isMonthlyChartVisible());
     }
@@ -97,6 +100,7 @@ class ManageServiceTest extends TestCase
         $sharedProjectTimesheet->setRecordMergeMode(RecordMergeMode::MODE_MERGE);
         $sharedProjectTimesheet->setEntryUserVisible(true);
         $sharedProjectTimesheet->setEntryRateVisible(true);
+        $sharedProjectTimesheet->setShowTotalAmountWhenEntryRateHidden(true);
         $sharedProjectTimesheet->setAnnualChartVisible(true);
         $sharedProjectTimesheet->setMonthlyChartVisible(true);
 
@@ -108,6 +112,7 @@ class ManageServiceTest extends TestCase
         self::assertEquals(RecordMergeMode::MODE_MERGE, $saved->getRecordMergeMode());
         self::assertTrue($saved->isEntryUserVisible());
         self::assertTrue($saved->isEntryRateVisible());
+        self::assertTrue($saved->isShowTotalAmountWhenEntryRateHidden());
         self::assertTrue($saved->isAnnualChartVisible());
         self::assertTrue($saved->isMonthlyChartVisible());
     }
@@ -144,5 +149,26 @@ class ManageServiceTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->service->update(new SharedProjectTimesheet());
+    }
+
+    public function testShowTotalAmountWhenEntryRateHiddenConfiguration(): void
+    {
+        $sharedProjectTimesheet = new SharedProjectTimesheet();
+        $sharedProjectTimesheet->setProject(new Project());
+
+        // Test default is true
+        self::assertTrue($sharedProjectTimesheet->isShowTotalAmountWhenEntryRateHidden());
+
+        // Test setting to false
+        $sharedProjectTimesheet->setShowTotalAmountWhenEntryRateHidden(false);
+        self::assertFalse($sharedProjectTimesheet->isShowTotalAmountWhenEntryRateHidden());
+
+        // Test setting back to true
+        $sharedProjectTimesheet->setShowTotalAmountWhenEntryRateHidden(true);
+        self::assertTrue($sharedProjectTimesheet->isShowTotalAmountWhenEntryRateHidden());
+
+        // Test persistence through service
+        $saved = $this->service->create($sharedProjectTimesheet, null);
+        self::assertTrue($saved->isShowTotalAmountWhenEntryRateHidden());
     }
 }

--- a/tests/Service/ManageServiceTest.php
+++ b/tests/Service/ManageServiceTest.php
@@ -45,6 +45,7 @@ class ManageServiceTest extends TestCase
         $sharedProjectTimesheet->setEntryUserVisible(true);
         $sharedProjectTimesheet->setEntryRateVisible(true);
         $sharedProjectTimesheet->setShowTotalAmountWhenEntryRateHidden(false);
+        $sharedProjectTimesheet->setProjectSubTotalsVisible(false);
         $sharedProjectTimesheet->setAnnualChartVisible(true);
         $sharedProjectTimesheet->setMonthlyChartVisible(true);
 
@@ -57,6 +58,7 @@ class ManageServiceTest extends TestCase
         self::assertTrue($saved->isEntryUserVisible());
         self::assertTrue($saved->isEntryRateVisible());
         self::assertFalse($saved->isShowTotalAmountWhenEntryRateHidden());
+        self::assertFalse($saved->isProjectSubTotalsVisible());
         self::assertTrue($saved->isAnnualChartVisible());
         self::assertTrue($saved->isMonthlyChartVisible());
     }
@@ -71,6 +73,7 @@ class ManageServiceTest extends TestCase
         self::assertFalse($sharedProjectTimesheet->isEntryUserVisible());
         self::assertFalse($sharedProjectTimesheet->isEntryRateVisible());
         self::assertTrue($sharedProjectTimesheet->isShowTotalAmountWhenEntryRateHidden());
+        self::assertTrue($sharedProjectTimesheet->isProjectSubTotalsVisible());
         self::assertFalse($sharedProjectTimesheet->isAnnualChartVisible());
         self::assertFalse($sharedProjectTimesheet->isMonthlyChartVisible());
     }
@@ -101,6 +104,7 @@ class ManageServiceTest extends TestCase
         $sharedProjectTimesheet->setEntryUserVisible(true);
         $sharedProjectTimesheet->setEntryRateVisible(true);
         $sharedProjectTimesheet->setShowTotalAmountWhenEntryRateHidden(true);
+        $sharedProjectTimesheet->setProjectSubTotalsVisible(true);
         $sharedProjectTimesheet->setAnnualChartVisible(true);
         $sharedProjectTimesheet->setMonthlyChartVisible(true);
 
@@ -113,6 +117,7 @@ class ManageServiceTest extends TestCase
         self::assertTrue($saved->isEntryUserVisible());
         self::assertTrue($saved->isEntryRateVisible());
         self::assertTrue($saved->isShowTotalAmountWhenEntryRateHidden());
+        self::assertTrue($saved->isProjectSubTotalsVisible());
         self::assertTrue($saved->isAnnualChartVisible());
         self::assertTrue($saved->isMonthlyChartVisible());
     }
@@ -170,5 +175,26 @@ class ManageServiceTest extends TestCase
         // Test persistence through service
         $saved = $this->service->create($sharedProjectTimesheet, null);
         self::assertTrue($saved->isShowTotalAmountWhenEntryRateHidden());
+    }
+
+    public function testProjectSubTotalsVisibleConfiguration(): void
+    {
+        $sharedProjectTimesheet = new SharedProjectTimesheet();
+        $sharedProjectTimesheet->setProject(new Project());
+
+        // Test default is true
+        self::assertTrue($sharedProjectTimesheet->isProjectSubTotalsVisible());
+
+        // Test setting to false
+        $sharedProjectTimesheet->setProjectSubTotalsVisible(false);
+        self::assertFalse($sharedProjectTimesheet->isProjectSubTotalsVisible());
+
+        // Test setting back to true
+        $sharedProjectTimesheet->setProjectSubTotalsVisible(true);
+        self::assertTrue($sharedProjectTimesheet->isProjectSubTotalsVisible());
+
+        // Test persistence through service
+        $saved = $this->service->create($sharedProjectTimesheet, null);
+        self::assertTrue($saved->isProjectSubTotalsVisible());
     }
 }


### PR DESCRIPTION
First of all, thank you for this plugin - it is really useful for my setup :)
I have made some improvements to the customer portal plugin in my fork.
I believe these changes might be useful for other users of the plugin too, hence this pull request.

Here are the imrovements made:
- Add possibility to (optionally) display the Activity and Tags of the timesheet entry on the Details.
- Added possibility to display the monthly total amount just below the total hours, when the entry rates are not visible. This way admin can chose not to display the rates and price for each entry, while keeping the total amount visible to the clients.
- Added possibility to display the sub-totals of hours and amounts for each project (configurable)
- Added breadcrumbs for navigating from Project details back to the Customer details. Improved the Details button link to preserve the currently selected month and year in query params.

No backward compatibility breaking changes.